### PR TITLE
removed check if state is available

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -10,6 +10,7 @@ class InfluxdbClient(RelationBase):
 
     @hook('{requires:influxdb-api}-relation-{joined,changed}')
     def changed(self):
+        #self.remove_state('{relation_name}.broken')
         self.set_state('{relation_name}.connected')
         data = {
             'hostname': self.hostname(),
@@ -22,5 +23,5 @@ class InfluxdbClient(RelationBase):
 
     @hook('{requires:influxdb-api}-relation-{broken,departed}')
     def broken(self):
-        if(is_state('{relation_name}.available')):
-            self.remove_state('{relation_name}.available')
+        self.remove_state('{relation_name}.available')
+        #self.set_state('{relation_name}.broken')


### PR DESCRIPTION
## Changes
### requires.py

```Python
@hook('{requires:influxdb-api}-relation-{broken,departed}')
def broken(self):
    if(is_state('{relation_name}.available')):
        self.remove_state('{relation_name}.available')
```
I removed the `if(is_state...` since I was having issues that when I remove my relationship in juju, The state `influxdb.available` was not removed. I don't think that it is necessary to check this because the charms should check if the relation has a certain state. Removing this state if the state does not exist, will not change anything to the charm.

#### added some states
I added an extra state but still placed it in comments since the current charms using this interface are not updated yet for the extra state. I think it's a good idea to use an extra states for when the relation is gone. Removing the `available` state is a good thing to check on in your charm but using a second state that only gets set when the relation is gone (`broken`) might be better. In this way when you check your current states for a charm, you can see that the relation that was there is now broken. 